### PR TITLE
Add markdown toolbar plugin skeleton with core actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.gradle/
+build/
+out/
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+  id 'java'
+  id 'org.jetbrains.intellij' version '1.17.2'
+}
+
+group 'com.example'
+version '0.1.0'
+
+repositories { mavenCentral() }
+
+intellij {
+  version = '2023.1'
+  plugins = ['org.intellij.plugins.markdown']
+}
+
+tasks.patchPluginXml {
+  sinceBuild = '231'
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+}
+
+test {
+  useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'markdown-gfm-toolbar'

--- a/src/main/java/com/example/mdgfm/MarkdownToolbarProvider.java
+++ b/src/main/java/com/example/mdgfm/MarkdownToolbarProvider.java
@@ -1,0 +1,49 @@
+package com.example.mdgfm;
+
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.toolbar.floating.AbstractFloatingToolbarProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Provides floating toolbar with Markdown/GFM actions.
+ */
+public class MarkdownToolbarProvider extends AbstractFloatingToolbarProvider {
+
+    private static final List<String> ACTION_IDS = List.of(
+            "MDGFM.Bold",
+            "MDGFM.Italic",
+            "MDGFM.InlineCode",
+            "MDGFM.Strike",
+            "MDGFM.CodeBlock",
+            "MDGFM.Heading",
+            "MDGFM.BulletList",
+            "MDGFM.OrderedList",
+            "MDGFM.Quote",
+            "MDGFM.TaskList",
+            "MDGFM.Suggestion",
+            "MDGFM.Table",
+            "MDGFM.Link",
+            "MDGFM.Mermaid",
+            "MDGFM.Details",
+            "MDGFM.DiffBlock"
+    );
+
+    public MarkdownToolbarProvider() {
+        super("MDGFM.Toolbar");
+    }
+
+    @Override
+    protected void registerActions(@NotNull List<? super AnAction> actions, @NotNull Editor editor) {
+        ActionManager am = ActionManager.getInstance();
+        ACTION_IDS.stream().map(am::getAction).forEach(actions::add);
+    }
+
+    @Override
+    protected boolean isApplicable(@NotNull Editor editor) {
+        return editor.getDocument().isWritable();
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/AbstractLineAction.java
+++ b/src/main/java/com/example/mdgfm/actions/AbstractLineAction.java
@@ -1,0 +1,33 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.SelectionUtils;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.command.WriteCommandAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+/** Action operating on whole lines. */
+public abstract class AbstractLineAction extends AbstractMdAction {
+
+    protected void transformLines(@NotNull AnActionEvent e, @NotNull Function<String, String> op) {
+        Editor editor = e.getRequiredData(CommonDataKeys.EDITOR);
+        Project project = e.getProject();
+        if (project == null) return;
+        Caret caret = editor.getCaretModel().getCurrentCaret();
+        TextRange range = SelectionUtils.selectionOrLines(editor);
+        Document doc = editor.getDocument();
+        String selected = doc.getText(range);
+        WriteCommandAction.runWriteCommandAction(project, () -> {
+            String replaced = op.apply(selected);
+            doc.replaceString(range.getStartOffset(), range.getEndOffset(), replaced);
+            caret.setSelection(range.getStartOffset(), range.getStartOffset() + replaced.length());
+        });
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/AbstractMdAction.java
+++ b/src/main/java/com/example/mdgfm/actions/AbstractMdAction.java
@@ -1,0 +1,41 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.SelectionUtils;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.command.WriteCommandAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+/** Base class for markdown actions operating on selection or caret. */
+public abstract class AbstractMdAction extends AnAction {
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        boolean enabled = editor != null && editor.getDocument().isWritable();
+        e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    protected void transform(@NotNull AnActionEvent e, @NotNull Function<String, String> op) {
+        Editor editor = e.getRequiredData(CommonDataKeys.EDITOR);
+        Project project = e.getProject();
+        if (project == null) return;
+        Caret caret = editor.getCaretModel().getCurrentCaret();
+        TextRange range = SelectionUtils.selectionOrWord(editor);
+        Document doc = editor.getDocument();
+        String selected = doc.getText(range);
+        WriteCommandAction.runWriteCommandAction(project, () -> {
+            String replaced = op.apply(selected);
+            doc.replaceString(range.getStartOffset(), range.getEndOffset(), replaced);
+            caret.setSelection(range.getStartOffset(), range.getStartOffset() + replaced.length());
+        });
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/BoldAction.java
+++ b/src/main/java/com/example/mdgfm/actions/BoldAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class BoldAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, t -> MdOps.toggleWrap(t, "**"));
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/BulletListAction.java
+++ b/src/main/java/com/example/mdgfm/actions/BulletListAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.LineOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class BulletListAction extends AbstractLineAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transformLines(e, LineOps::toggleBullet);
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/CodeBlockAction.java
+++ b/src/main/java/com/example/mdgfm/actions/CodeBlockAction.java
@@ -1,0 +1,16 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
+import org.jetbrains.annotations.NotNull;
+
+public class CodeBlockAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        String lang = Messages.showInputDialog(e.getProject(), "Language", "Code Block", null);
+        if (lang == null) lang = "";
+        final String l = lang;
+        transform(e, sel -> MdOps.fencedBlock(l, sel));
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/DetailsAction.java
+++ b/src/main/java/com/example/mdgfm/actions/DetailsAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class DetailsAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, sel -> MdOps.details());
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/DiffBlockAction.java
+++ b/src/main/java/com/example/mdgfm/actions/DiffBlockAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class DiffBlockAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, sel -> MdOps.diffBlock());
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/HeadingCycleAction.java
+++ b/src/main/java/com/example/mdgfm/actions/HeadingCycleAction.java
@@ -1,0 +1,17 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.LineOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class HeadingCycleAction extends AbstractLineAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transformLines(e, sel -> Arrays.stream(sel.split("\n", -1))
+                .map(LineOps::cycleHeading)
+                .collect(Collectors.joining("\n")));
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/InlineCodeAction.java
+++ b/src/main/java/com/example/mdgfm/actions/InlineCodeAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class InlineCodeAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, t -> MdOps.toggleWrap(t, "`") );
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/ItalicAction.java
+++ b/src/main/java/com/example/mdgfm/actions/ItalicAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class ItalicAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, t -> MdOps.toggleWrap(t, "*"));
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/LinkAction.java
+++ b/src/main/java/com/example/mdgfm/actions/LinkAction.java
@@ -1,0 +1,18 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
+import org.jetbrains.annotations.NotNull;
+
+public class LinkAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        String url = Messages.showInputDialog(e.getProject(), "URL", "Insert Link", null, "https://", null);
+        if (url == null) return;
+        transform(e, sel -> {
+            String text = sel.isBlank() ? "text" : sel;
+            return MdOps.link(text, url);
+        });
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/MermaidAction.java
+++ b/src/main/java/com/example/mdgfm/actions/MermaidAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class MermaidAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, sel -> MdOps.mermaid());
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/OrderedListAction.java
+++ b/src/main/java/com/example/mdgfm/actions/OrderedListAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.LineOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class OrderedListAction extends AbstractLineAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transformLines(e, LineOps::toggleOrdered);
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/QuoteAction.java
+++ b/src/main/java/com/example/mdgfm/actions/QuoteAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.LineOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class QuoteAction extends AbstractLineAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transformLines(e, LineOps::toggleQuote);
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/StrikeAction.java
+++ b/src/main/java/com/example/mdgfm/actions/StrikeAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class StrikeAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, t -> MdOps.toggleWrap(t, "~~"));
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/SuggestionAction.java
+++ b/src/main/java/com/example/mdgfm/actions/SuggestionAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class SuggestionAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, MdOps::suggestionBlock);
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/TableAction.java
+++ b/src/main/java/com/example/mdgfm/actions/TableAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.MdOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class TableAction extends AbstractMdAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transform(e, sel -> MdOps.table());
+    }
+}

--- a/src/main/java/com/example/mdgfm/actions/TaskListAction.java
+++ b/src/main/java/com/example/mdgfm/actions/TaskListAction.java
@@ -1,0 +1,12 @@
+package com.example.mdgfm.actions;
+
+import com.example.mdgfm.core.LineOps;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class TaskListAction extends AbstractLineAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        transformLines(e, LineOps::toggleTask);
+    }
+}

--- a/src/main/java/com/example/mdgfm/core/LineOps.java
+++ b/src/main/java/com/example/mdgfm/core/LineOps.java
@@ -1,0 +1,69 @@
+package com.example.mdgfm.core;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.regex.Pattern;
+
+public final class LineOps {
+    private LineOps() {}
+
+    public static String toggleBullet(String text) {
+        String[] lines = text.split("\n", -1);
+        boolean all = Arrays.stream(lines).filter(l -> !l.isBlank()).allMatch(l -> l.trim().startsWith("- "));
+        return Arrays.stream(lines).map(l -> {
+            if (l.isBlank()) return l;
+            if (all) return l.replaceFirst("^\\s*- ", "");
+            return "- " + l;
+        }).collect(Collectors.joining("\n"));
+    }
+
+    public static String toggleOrdered(String text) {
+        String[] lines = text.split("\n", -1);
+        Pattern p = Pattern.compile("^\\s*\\d+\\. ");
+        boolean all = Arrays.stream(lines).filter(l -> !l.isBlank()).allMatch(l -> p.matcher(l).find());
+        if (all) {
+            return Arrays.stream(lines).map(l -> {
+                if (l.isBlank()) return l;
+                return l.replaceFirst("^\\s*\\d+\\. ", "");
+            }).collect(Collectors.joining("\n"));
+        }
+        int[] i = {1};
+        return Arrays.stream(lines).map(l -> {
+            if (l.isBlank()) return l;
+            return (i[0]++) + ". " + l;
+        }).collect(Collectors.joining("\n"));
+    }
+
+    public static String toggleQuote(String text) {
+        String[] lines = text.split("\n", -1);
+        boolean all = Arrays.stream(lines).filter(l -> !l.isBlank()).allMatch(l -> l.trim().startsWith(">"));
+        return Arrays.stream(lines).map(l -> {
+            if (l.isBlank()) return l;
+            if (all) return l.replaceFirst("^\\s*> ?", "");
+            return "> " + l;
+        }).collect(Collectors.joining("\n"));
+    }
+
+    public static String toggleTask(String text) {
+        String[] lines = text.split("\n", -1);
+        Pattern p = Pattern.compile("^\\s*- \\[\\[( |x|X)\\]\\] ");
+        boolean all = Arrays.stream(lines).filter(l -> !l.isBlank()).allMatch(l -> p.matcher(l).find());
+        return Arrays.stream(lines).map(l -> {
+            if (l.isBlank()) return l;
+            if (all) return l.replaceFirst("^\\s*- \\[\\[( |x|X)\\]\\] ", "- ");
+            return "- [ ] " + l;
+        }).collect(Collectors.joining("\n"));
+    }
+
+    public static String cycleHeading(String line) {
+        String trimmed = line.stripLeading();
+        if (trimmed.startsWith("### ")) {
+            return trimmed.substring(4);
+        } else if (trimmed.startsWith("## ")) {
+            return "### " + trimmed.substring(3);
+        } else if (trimmed.startsWith("# ")) {
+            return "## " + trimmed.substring(2);
+        }
+        return "# " + line;
+    }
+}

--- a/src/main/java/com/example/mdgfm/core/MdOps.java
+++ b/src/main/java/com/example/mdgfm/core/MdOps.java
@@ -1,0 +1,43 @@
+package com.example.mdgfm.core;
+
+public final class MdOps {
+    private MdOps() {}
+
+    public static String toggleWrap(String text, String marker) {
+        String trimmed = text.trim();
+        if (trimmed.startsWith(marker) && trimmed.endsWith(marker) && trimmed.length() >= marker.length() * 2) {
+            String core = trimmed.substring(marker.length(), trimmed.length() - marker.length());
+            return text.replace(trimmed, core);
+        }
+        return marker + text + marker;
+    }
+
+    public static String fencedBlock(String lang, String body) {
+        if (lang == null) lang = "";
+        return "```" + lang + "\n" + body + "\n```";
+    }
+
+    public static String suggestionBlock(String body) {
+        return fencedBlock("suggestion", body.isBlank() ? "// your change here" : body);
+    }
+
+    public static String table() {
+        return "| Col1 | Col2 |\n| :--- | ---: |\n|      |      |";
+    }
+
+    public static String mermaid() {
+        return "```mermaid\ngraph TD\n  A --> B\n```";
+    }
+
+    public static String details() {
+        return "<details>\n<summary>Click to expand</summary>\n\nContent…\n\n</details>";
+    }
+
+    public static String diffBlock() {
+        return "```diff\n+ added\n- removed\n```";
+    }
+
+    public static String link(String text, String url) {
+        return "[" + text + "](" + url + ")";
+    }
+}

--- a/src/main/java/com/example/mdgfm/core/SelectionUtils.java
+++ b/src/main/java/com/example/mdgfm/core/SelectionUtils.java
@@ -1,0 +1,44 @@
+package com.example.mdgfm.core;
+
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+
+public final class SelectionUtils {
+    private SelectionUtils() {}
+
+    public static TextRange selectionOrWord(Editor editor) {
+        Caret caret = editor.getCaretModel().getCurrentCaret();
+        if (caret.hasSelection()) {
+            return new TextRange(caret.getSelectionStart(), caret.getSelectionEnd());
+        }
+        Document doc = editor.getDocument();
+        CharSequence text = doc.getCharsSequence();
+        int offset = caret.getOffset();
+        int start = offset;
+        while (start > 0 && !Character.isWhitespace(text.charAt(start - 1))) start--;
+        int end = offset;
+        while (end < text.length() && !Character.isWhitespace(text.charAt(end))) end++;
+        caret.setSelection(start, end);
+        return new TextRange(start, end);
+    }
+
+    public static TextRange selectionOrLines(Editor editor) {
+        Caret caret = editor.getCaretModel().getCurrentCaret();
+        Document doc = editor.getDocument();
+        if (caret.hasSelection()) {
+            int startLine = doc.getLineNumber(caret.getSelectionStart());
+            int endLine = doc.getLineNumber(caret.getSelectionEnd());
+            int start = doc.getLineStartOffset(startLine);
+            int end = doc.getLineEndOffset(endLine);
+            caret.setSelection(start, end);
+            return new TextRange(start, end);
+        }
+        int line = doc.getLineNumber(caret.getOffset());
+        int start = doc.getLineStartOffset(line);
+        int end = doc.getLineEndOffset(line);
+        caret.setSelection(start, end);
+        return new TextRange(start, end);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,32 @@
+<idea-plugin>
+  <id>com.example.markdown.gfm.toolbar</id>
+  <name>Markdown GFM Toolbar</name>
+  <vendor email="you@example.com">You</vendor>
+  <version>0.1.0</version>
+  <idea-version since-build="231.0"/>
+  <depends>com.intellij.modules.platform</depends>
+  <depends optional="true">org.intellij.plugins.markdown</depends>
+
+  <extensions defaultExtensionNs="com.intellij">
+    <editorFloatingToolbarProvider implementation="com.example.mdgfm.MarkdownToolbarProvider"/>
+  </extensions>
+
+  <actions>
+    <action id="MDGFM.Bold" class="com.example.mdgfm.actions.BoldAction" text="Bold" description="**bold**"/>
+    <action id="MDGFM.Italic" class="com.example.mdgfm.actions.ItalicAction" text="Italic" description="*italic*"/>
+    <action id="MDGFM.InlineCode" class="com.example.mdgfm.actions.InlineCodeAction" text="Code" description="`code`"/>
+    <action id="MDGFM.Strike" class="com.example.mdgfm.actions.StrikeAction" text="Strike"/>
+    <action id="MDGFM.CodeBlock" class="com.example.mdgfm.actions.CodeBlockAction" text="Code Block" description="```lang```"/>
+    <action id="MDGFM.Heading" class="com.example.mdgfm.actions.HeadingCycleAction" text="Heading"/>
+    <action id="MDGFM.BulletList" class="com.example.mdgfm.actions.BulletListAction" text="Bulleted List"/>
+    <action id="MDGFM.OrderedList" class="com.example.mdgfm.actions.OrderedListAction" text="Ordered List"/>
+    <action id="MDGFM.Quote" class="com.example.mdgfm.actions.QuoteAction" text="Quote"/>
+    <action id="MDGFM.TaskList" class="com.example.mdgfm.actions.TaskListAction" text="Task List"/>
+    <action id="MDGFM.Suggestion" class="com.example.mdgfm.actions.SuggestionAction" text="Suggestion"/>
+    <action id="MDGFM.Table" class="com.example.mdgfm.actions.TableAction" text="Table"/>
+    <action id="MDGFM.Link" class="com.example.mdgfm.actions.LinkAction" text="Link"/>
+    <action id="MDGFM.Mermaid" class="com.example.mdgfm.actions.MermaidAction" text="Mermaid"/>
+    <action id="MDGFM.Details" class="com.example.mdgfm.actions.DetailsAction" text="Details"/>
+    <action id="MDGFM.DiffBlock" class="com.example.mdgfm.actions.DiffBlockAction" text="Diff Block"/>
+  </actions>
+</idea-plugin>

--- a/src/test/java/com/example/mdgfm/core/MdOpsTest.java
+++ b/src/test/java/com/example/mdgfm/core/MdOpsTest.java
@@ -1,0 +1,58 @@
+package com.example.mdgfm.core;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MdOpsTest {
+
+    @Test
+    void boldToggle() {
+        assertEquals("**text**", MdOps.toggleWrap("text", "**"));
+        assertEquals("text", MdOps.toggleWrap("**text**", "**"));
+    }
+
+    @Test
+    void inlineCode() {
+        assertEquals("`code`", MdOps.toggleWrap("code", "`"));
+        assertEquals("code", MdOps.toggleWrap("`code`", "`"));
+    }
+
+    @Test
+    void bulletList() {
+        String out = LineOps.toggleBullet("a\nb");
+        assertEquals("- a\n- b", out);
+        assertEquals("a\nb", LineOps.toggleBullet(out));
+    }
+
+    @Test
+    void orderedList() {
+        String out = LineOps.toggleOrdered("a\nb");
+        assertEquals("1. a\n2. b", out);
+        assertEquals("a\nb", LineOps.toggleOrdered(out));
+    }
+
+    @Test
+    void headingCycle() {
+        assertEquals("# title", LineOps.cycleHeading("title"));
+        assertEquals("## title", LineOps.cycleHeading("# title"));
+        assertEquals("### title", LineOps.cycleHeading("## title"));
+        assertEquals("title", LineOps.cycleHeading("### title"));
+    }
+
+    @Test
+    void taskList() {
+        String out = LineOps.toggleTask("task");
+        assertEquals("- [ ] task", out);
+        assertEquals("task", LineOps.toggleTask(out));
+    }
+
+    @Test
+    void suggestionBlock() {
+        assertEquals("```suggestion\nabc\n```", MdOps.suggestionBlock("abc"));
+    }
+
+    @Test
+    void tableSnippet() {
+        assertTrue(MdOps.table().contains("| Col1 |"));
+    }
+}


### PR DESCRIPTION
## Summary
- set up Gradle project for IntelliJ plugin
- implement floating Markdown/GFM toolbar provider
- add core text actions and utilities with basic tests

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.intellij', version: '1.17.2'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1e3d709c832a9cc57388c7aa10cd