### PR TITLE
chore: update IntelliJ Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.jetbrains.intellij' version '1.17.2'
+  id 'org.jetbrains.intellij' version '1.17.4'
 }
 
 group 'com.example'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+  repositories {
+    maven { url 'https://cache-redirector.jetbrains.com/plugins.gradle.org/m2' }
+    maven { url 'https://maven.pkg.jetbrains.space/public/p/gradle-plugins/gradle-plugins' }
+    gradlePluginPortal()
+  }
+}
+
 rootProject.name = 'markdown-gfm-toolbar'


### PR DESCRIPTION
## Summary
- bump org.jetbrains.intellij Gradle plugin to 1.17.4
- include JetBrains plugin repositories in settings.gradle for plugin resolution

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.intellij', version: '1.17.4'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a24b25a84832aa563e004e2664ce5