### PR TITLE
Fix task list toggling regex

### DIFF
--- a/src/main/java/com/example/mdgfm/core/LineOps.java
+++ b/src/main/java/com/example/mdgfm/core/LineOps.java
@@ -46,11 +46,13 @@ public final class LineOps {
 
     public static String toggleTask(String text) {
         String[] lines = text.split("\n", -1);
-        Pattern p = Pattern.compile("^\\s*- \\[\\[( |x|X)\\]\\] ");
-        boolean all = Arrays.stream(lines).filter(l -> !l.isBlank()).allMatch(l -> p.matcher(l).find());
+        Pattern p = Pattern.compile("^\\s*- \\[( |x|X)\\] ");
+        boolean all = Arrays.stream(lines)
+            .filter(l -> !l.isBlank())
+            .allMatch(l -> p.matcher(l).find());
         return Arrays.stream(lines).map(l -> {
             if (l.isBlank()) return l;
-            if (all) return l.replaceFirst("^\\s*- \\[\\[( |x|X)\\]\\] ", "- ");
+            if (all) return l.replaceFirst("^\\s*- \\[( |x|X)\\] ", "");
             return "- [ ] " + l;
         }).collect(Collectors.joining("\n"));
     }


### PR DESCRIPTION
## Summary
- correct task list regex to recognize existing task prefixes
- ensure toggling removes task markers instead of leaving a bullet

## Testing
- `gradle test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.9.3, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a2e1f1974832abfa827822571a031