### PR TITLE
Expand IDE compatibility to future versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ intellij {
 
 tasks.patchPluginXml {
   sinceBuild = '231'
+  untilBuild = '999.*'
 }
 
 java {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   <name>Markdown GFM Toolbar</name>
   <vendor email="you@example.com">You</vendor>
   <version>0.1.0</version>
-  <idea-version since-build="231.0"/>
+  <idea-version since-build="231" until-build="999.*"/>
   <depends>com.intellij.modules.platform</depends>
   <depends optional="true">org.intellij.plugins.markdown</depends>
 


### PR DESCRIPTION
## Summary
- broaden IntelliJ compatibility to any build up to 999.*
- include explicit compatibility range in plugin.xml

## Testing
- `gradle patchPluginXml`
- `gradle test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.9.3, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a56e14894832aa5039bd9b29ee1f1