### PR TITLE
docs: base persuasive readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# markdown-toolbar-plugin
+# Markdown PowerBar *(nombre sugerido)*
+
+**Tu aliado para escribir Markdown sin fricción dentro de JetBrains.**  
+Domina tus revisiones de código y documentos con una barra de herramientas intuitiva que aparece justo donde la necesitas.
+
+## ¿Por qué otro plugin más?
+
+- **Acelera tu flujo de trabajo**: olvida los atajos enrevesados y dale formato a tu Markdown con un clic.
+- **Gana claridad en tus PRs**: tus ideas brillan cuando la presentación es impecable.
+- **Únete a quienes ya simplificaron su día a día**: la comunidad va creciendo y tu voz puede guiar el rumbo.
+
+## Características principales
+
+- Botones para **negrita**, *cursiva*, ~~tachado~~, código en línea y más.
+- Soporte para listas, tablas, enlaces, bloques de código, Mermaid, detalles y citas.
+- Atajo `Ctrl + Alt + M` para mostrar la barra si el entorno la oculta.
+
+## Instalación
+
+1. Clona este repositorio.
+2. Ejecuta `gradle build` para generar el plugin.
+3. Importa el artefacto `build/distributions/*.zip` en tu IDE JetBrains (Settings → Plugins → Install plugin from disk).
+
+## Contribuye y hazlo tuyo
+
+Apreciamos cada comentario, issue o pull request. Cuéntanos qué necesitarías y encontraremos una solución juntos.  
+Tu experiencia es la brújula que orienta la evolución del proyecto.
+
+## Nombre del proyecto
+
+El repositorio se llama hoy **markdown-toolbar-plugin**, pero creemos que **Markdown PowerBar** comunica mejor su propósito.  
+¿Tienes un nombre aún más inspirador? ¡Estamos listos para escucharte!
+


### PR DESCRIPTION
## Summary
- add persuasive, user-friendly README proposing new repo name

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (proxy 403))*
- `./gradlew build` *(fails: Could not get resource from Maven Central, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689befb559d0832aa022b12596b81140